### PR TITLE
Fix how greater-than sign appears and add functionality to tapping on comment text

### DIFF
--- a/App/Views/Post/Elements/Comment/index.js
+++ b/App/Views/Post/Elements/Comment/index.js
@@ -134,6 +134,7 @@ var Comment = React.createClass({
     			   		  .replace('</i>', '')
     			   		  .replace(/&#x27;/g, '\'')
     			   		  .replace(/&quot;/g, '\"')
+    			   		  .replace(/&gt;/g, '>')
     			   		  .replace(/<a\s+(?:[^>]*?\s+)?href="([^"]*)" rel="nofollow">(.*)?<\/a>/g, "$1");
     }
 });

--- a/App/Views/Post/Elements/Comment/index.js
+++ b/App/Views/Post/Elements/Comment/index.js
@@ -26,7 +26,7 @@ var Comment = React.createClass({
 					<Text style={styles.commentBy}>
 						{this.props.data.by}:
 					</Text>
-					<Text style={styles.commentText}>
+					<Text style={styles.commentText} onPress={()=>this.onShowReplies()}>
 						{this.fixCommentText(this.props.data.text)}
 					</Text>
 					{this.renderRepliesControlButton()}

--- a/App/Views/Post/index.ios.js
+++ b/App/Views/Post/index.ios.js
@@ -138,6 +138,7 @@ module.exports = React.createClass({
                   .replace('</i>', '')
                   .replace(/&#x27;/g, '\'')
                   .replace(/&quot;/g, '\"')
+                  .replace(/&gt;/g, '>')
                   .replace(/<a\s+(?:[^>]*?\s+)?href="([^"]*)" rel="nofollow">(.*)?<\/a>/g, "$1");
   }
 });


### PR DESCRIPTION
The '>' sign currently shows as `&gt;` ; this fixes that.

Important only because HN commenters often use the '>' sign to
signify that they are quoting the previous commenter.

Added tappability to comment text as well.
