### PR TITLE
Fix alignment of numbers in post list view

### DIFF
--- a/App/Views/Dashboard/index.ios.js
+++ b/App/Views/Dashboard/index.ios.js
@@ -163,11 +163,12 @@ var styles = StyleSheet.create({
         alignItems: 'center',
     },
     rowCount: {
+        fontFamily: 'Helvetica Neue',
         fontSize: 20,
         textAlign: 'right',
         color: 'gray',
+        width: 23,
         margin: 10,
-        marginLeft: 15,
     },
     rowDetailsContainer: {
         flex: 1,


### PR DESCRIPTION
Currently, going from single digit numbers to double digit
numbers pushes the post title to the right, making it look
uneven. This sets a minimum width and uses a monospaced
font in order to stop that, although this is too rigid to
work for three digit numbers. Seems to be rare that a user
ever gets to >99 posts loaded though.
