### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Hacker News](https://news.ycombinator.com/) reader for iOS and Android, made with [React-Native](https://github.com/facebook/react-native).
 
-##DEMO
+## DEMO
 [![App Store Button](http://imgur.com/y8PTxr9.png "App Store Button")](https://itunes.apple.com/ca/app/hacker-news-reader-react-native/id1067161633?mt=8)
 [![Play Store Button](http://imgur.com/utWa1co.png "Play Store Button")](https://play.google.com/store/apps/details?id=com.hackernews)
 
@@ -17,17 +17,17 @@
 ![Android Preview Gif 1](http://i.imgur.com/88ZW3Ls.gif "Android Preview Gif 1")
 ![Android Preview Gif 2](http://i.imgur.com/DWjd4zM.gif "Android Preview Gif 2")
 
-##Features/Components
+## Features/Components
 - Uses React Native 0.20
 - Pull down to Refresh listview
 - Pagination listview
 - Comment & Sub Comments
 - WebView to view source pages
 
-##Installation
+## Installation
 Once you have downloaded or cloned this repository, run `npm install` inside the directory.
 
-##Usage
+## Usage
 - [Setting up React Native for Android](https://facebook.github.io/react-native/docs/android-setup.html#content)
 - [Running app on Android Device](https://facebook.github.io/react-native/docs/running-on-device-android.html#content)
 - [Running app on iOS Device](https://facebook.github.io/react-native/docs/running-on-device-ios.html#content)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
